### PR TITLE
Support xcode-select

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set(man_sources
 )
 
 add_darling_executable(man ${man_sources})
-target_link_libraries(man system)
+target_link_libraries(man system xcselect)
 
 install(TARGETS man DESTINATION libexec/darling/usr/bin)
 

--- a/src/manpath.c
+++ b/src/manpath.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <xcselect.h>
 
 /* not always in <string.h> */
 extern char *index(const char *, int);
@@ -364,6 +365,22 @@ add_default_manpath (int perrs) {
      for (dlp = cfdirlist.nxt; dlp; dlp = dlp->nxt)
 	  if (dlp->mandatory)
 	       add_to_mandirlist (dlp->mandir, perrs);
+
+    xcselect_manpaths *xcp;
+    const char *path;
+    unsigned i, count;
+    // TODO: pass something for sdkname
+    xcp = xcselect_get_manpaths(NULL);
+    if (xcp != NULL) {
+	count = xcselect_manpaths_get_num_paths(xcp);
+	for (i = 0; i < count; i++) {
+	    path = xcselect_manpaths_get_path(xcp, i);
+	    if (path != NULL) {
+		add_to_mandirlist((char *)path, perrs);
+	    }
+	}
+	xcselect_manpaths_free(xcp);
+    }
 }
 
 static void


### PR DESCRIPTION
Based on [PR11291804-xcode.diff](https://opensource.apple.com/source/man/man-16/patches/PR11291804-xcode.diff.auto.html)

Btw, [src__manpath.c.diff](https://opensource.apple.com/source/man/man-16/patches/src__manpath.c.diff.auto.html)is also worth checking _(but is not included)_ -- it adds `share/man` to `find_man_subdir`. 
